### PR TITLE
Fix ai goat movement logic

### DIFF
--- a/lib/logic/game_controller.dart
+++ b/lib/logic/game_controller.dart
@@ -404,7 +404,7 @@ class GameController extends ChangeNotifier {
 
     // Hard mode priority 2: on square board, cover outer walls before center (early phase)
     if (difficulty == Difficulty.hard && boardType == BoardType.square) {
-      if (placedGoats < 12) {
+      if (placedGoats <= 12) {
         final wallEmpties = emptyPoints.where(_isEdgeSquare).toList();
         if (wallEmpties.isNotEmpty) {
           emptyPoints = wallEmpties;
@@ -458,7 +458,7 @@ class GameController extends ChangeNotifier {
 
         double score = 0;
         // Emphasize edges early
-        score += _calculateOuterWallScore(point) * (placedGoats < 12 ? 800 : 300);
+        score += _calculateOuterWallScore(point) * (placedGoats <= 12 ? 800 : 300);
         score += _calculateBlockScoreForBoard(boardClone, simulated) * 300;
         score += _clusterBonus(boardClone, simulated) * 200;
 
@@ -1577,7 +1577,7 @@ class GameController extends ChangeNotifier {
 
     // Dynamic weights: early placement favors edges more; later favor connectivity
     final bool inPlacementPhase = !isGoatMovementPhase;
-    final bool earlyPlacement = inPlacementPhase && placedGoats < 12;
+    final bool earlyPlacement = inPlacementPhase && placedGoats <= 12;
     final double edgesWeight = earlyPlacement ? 20.0 : 6.0;
     final double connectivityWeight = inPlacementPhase && !earlyPlacement ? 10.0 : 8.0;
 


### PR DESCRIPTION
Extend the AI's 'early phase' goat placement logic to include the 13th goat to ensure continued edge preference.

The hard AI's "early phase" logic, which prioritizes edge placements, was prematurely deactivated after the 12th goat. This led to an incorrect 13th goat placement (e.g., at 1,2) that did not follow the intended edge-priority strategy. This change ensures the 13th goat placement correctly falls under the early phase.

---
<a href="https://cursor.com/background-agent?bcId=bc-4c1bc246-033b-4634-ac59-473cb7063989">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4c1bc246-033b-4634-ac59-473cb7063989">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

