### PR TITLE
Fix hard mode ai goat blocking

### DIFF
--- a/lib/logic/game_controller.dart
+++ b/lib/logic/game_controller.dart
@@ -403,6 +403,45 @@ class GameController extends ChangeNotifier {
       // If there are no landing blocks, continue with other priorities
     }
 
+    // Hard mode priority 1.5: preempt future tiger jumps (after a single tiger step)
+    if (difficulty == Difficulty.hard && boardType == BoardType.square) {
+      final nextTurnLandingCandidates = _predictNextTurnLandingBlocksSquare();
+      if (nextTurnLandingCandidates.isNotEmpty) {
+        Point? bestFutureBlock;
+        double bestFutureScore = double.negativeInfinity;
+        for (final cand in nextTurnLandingCandidates) {
+          final bClone = _cloneSquareBoard(board);
+          final landC = bClone[cand.x][cand.y];
+          landC.type = PieceType.goat;
+          // Avoid placements where the new goat is immediately capturable
+          if (_tigerCanCaptureAfter(bClone, landC)) {
+            continue;
+          }
+          double score = 0.0;
+          // Prefer outer edges slightly less than direct blocks
+          score += _calculateOuterWallScore(cand) * 400;
+          // Prefer placements that reduce predicted next-turn jump threats
+          final int preThreatsBefore = _countNextTurnJumpThreatsOn(board);
+          final int preThreatsAfter = _countNextTurnJumpThreatsOn(bClone);
+          score += (preThreatsBefore - preThreatsAfter) * 600.0;
+          // Minor cluster/connectivity bonuses
+          score += _clusterBonus(bClone, landC) * 150;
+          final int initialMobility = _calculateTigerMobility(board);
+          final int reducedMobility = _calculateTigerMobility(bClone);
+          score += (reducedMobility < initialMobility) ? 200.0 : 0.0;
+          if (score > bestFutureScore) {
+            bestFutureScore = score;
+            bestFutureBlock = cand;
+          }
+        }
+        if (bestFutureBlock != null) {
+          debugPrint("[hard AI] Preemptively blocking future jump by placing at ${bestFutureBlock.x}, ${bestFutureBlock.y}");
+          _placeGoat(bestFutureBlock);
+          return;
+        }
+      }
+    }
+
     // Hard mode priority 2: on square board, strictly cover outer walls before center until edges filled
     if (difficulty == Difficulty.hard && boardType == BoardType.square) {
       final wallEmpties = emptyPoints.where(_isEdgeSquare).toList();
@@ -444,7 +483,6 @@ class GameController extends ChangeNotifier {
     if (boardType == BoardType.square) {
       for (var point in emptyPoints) {
         if (unsafeMoveHistory.contains('${point.x},${point.y}')) continue;
-
         // Simulate on a cloned board; do not mutate the real board
         final boardClone = _cloneSquareBoard(board);
         final simulated = boardClone[point.x][point.y];
@@ -1810,6 +1848,75 @@ class GameController extends ChangeNotifier {
       if (square.SquareBoardLogic.getValidMoves(tiger, boardState).isEmpty) blocked++;
     }
     return blocked;
+  }
+
+  // Return predicted landing squares where a tiger could perform a jump after a single legal step (no jump) this turn
+  List<Point> _predictNextTurnLandingBlocksSquare() {
+    final Set<String> seen = {};
+    final List<Point> result = [];
+    for (final tiger in board.expand((row) => row).where((p) => p.type == PieceType.tiger)) {
+      final moves = square.SquareBoardLogic.getValidMoves(tiger, board);
+      for (final dest in moves) {
+        // consider only non-jump tiger steps
+        if ((dest.x - tiger.x).abs() == 2 || (dest.y - tiger.y).abs() == 2) continue;
+        final tb = _cloneSquareBoard(board);
+        final tf = tb[tiger.x][tiger.y];
+        final tt = tb[dest.x][dest.y];
+        tf.type = PieceType.empty;
+        tt.type = PieceType.tiger;
+        final futureThreats = _getCurrentJumpThreatsOn(tb);
+        for (final thr in futureThreats) {
+          final lx = thr.landing.x;
+          final ly = thr.landing.y;
+          if (board[lx][ly].type != PieceType.empty) continue;
+          final key = '$lx,$ly';
+          if (seen.add(key)) {
+            result.add(board[lx][ly]);
+          }
+        }
+      }
+    }
+    return result;
+  }
+
+  // Count predicted next-turn jump threats for the square board
+  int _countNextTurnJumpThreatsOn(List<List<Point>> boardState) {
+    int total = 0;
+    for (final tiger in boardState.expand((row) => row).where((p) => p.type == PieceType.tiger)) {
+      final moves = square.SquareBoardLogic.getValidMoves(tiger, boardState);
+      for (final dest in moves) {
+        // only non-jump steps
+        if ((dest.x - tiger.x).abs() == 2 || (dest.y - tiger.y).abs() == 2) continue;
+        final tb = _cloneSquareBoard(boardState);
+        final tf = tb[tiger.x][tiger.y];
+        final tt = tb[dest.x][dest.y];
+        tf.type = PieceType.empty;
+        tt.type = PieceType.tiger;
+        total += _countJumpThreatsOn(tb);
+      }
+    }
+    return total;
+  }
+
+  // Build current jump threats for an arbitrary square board state
+  List<_JumpThreat> _getCurrentJumpThreatsOn(List<List<Point>> boardState) {
+    final threats = <_JumpThreat>[];
+    for (final tiger in boardState.expand((row) => row).where((p) => p.type == PieceType.tiger)) {
+      for (final adj in tiger.adjacentPoints) {
+        if (adj.type != PieceType.goat) continue;
+        final dx = adj.x - tiger.x;
+        final dy = adj.y - tiger.y;
+        final lx = adj.x + dx;
+        final ly = adj.y + dy;
+        if (lx >= 0 && lx < 5 && ly >= 0 && ly < 5) {
+          final landing = boardState[lx][ly];
+          if (landing.type == PieceType.empty && adj.adjacentPoints.contains(landing)) {
+            threats.add(_JumpThreat(tiger: tiger, victim: adj, landing: landing));
+          }
+        }
+      }
+    }
+    return threats;
   }
 
   int _countUnsafeGoatsOn(List<List<Point>> boardState) {


### PR DESCRIPTION
Implement a new hard mode AI strategy to preemptively block future tiger jumps on the square board.

The previous hard mode AI was not effectively blocking tiger movements, allowing tigers to set up jumps too easily. This change introduces a new priority that analyzes potential tiger moves one turn ahead and places goats to block predicted landing squares, significantly improving the AI's defensive capabilities.

---
<a href="https://cursor.com/background-agent?bcId=bc-de8a368a-fbae-41e7-aae0-8dc567237e13">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-de8a368a-fbae-41e7-aae0-8dc567237e13">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

