### PR TITLE
Fix tiger movement logic for single tiger turn

### DIFF
--- a/lib/logic/game_controller.dart
+++ b/lib/logic/game_controller.dart
@@ -142,6 +142,7 @@ class GameController extends ChangeNotifier {
 
   void makeComputerMove() {
     if (!_isComputerTurn() || gameMessage != null || isPaused) return;
+    final PieceType movedSide = currentTurn;
     if (currentTurn == PieceType.tiger) {
       if (boardType == BoardType.square) {
         _makeSquareComputerMove();
@@ -154,7 +155,12 @@ class GameController extends ChangeNotifier {
     _playTurnAudio();
     _checkWinConditions();
 
-    if (gameMode == GameMode.pvc && gameMessage == null && isComputerTurn()) {
+    // Only schedule another computer move if the turn actually switched
+    // to the opponent and that opponent is also controlled by the computer.
+    if (gameMode == GameMode.pvc &&
+        gameMessage == null &&
+        isComputerTurn() &&
+        currentTurn != movedSide) {
       scheduleComputerMove(duration: const Duration(milliseconds: 400));
     }
   }
@@ -172,18 +178,7 @@ class GameController extends ChangeNotifier {
     if (moves.isEmpty) return;
     final move = _selectMoveBasedOnDifficulty(moves);
     _executeMove(move['from']!, move['to']!);
-    if (currentTurn == PieceType.tiger) {
-      currentTurn = PieceType.goat;
-      bool allBlocked = _areAllGoatsBlocked();
-      if (allBlocked) {
-        gameMessage = "Goat's turn is skipped";
-        currentTurn = PieceType.tiger;
-        notifyListeners();
-        return;
-      }
-    } else {
-      currentTurn = PieceType.tiger;
-    }
+    currentTurn = currentTurn == PieceType.tiger ? PieceType.goat : PieceType.tiger;
     selectedPiece = null;
     validMoves = [];
     if (gameMessage == "Goat's turn is skipped") gameMessage = null;
@@ -226,18 +221,7 @@ class GameController extends ChangeNotifier {
       }
     }
     _executeMove(move['from']!, move['to']!);
-    if (currentTurn == PieceType.tiger) {
-      currentTurn = PieceType.goat;
-      bool allBlocked = _areAllGoatsBlocked();
-      if (allBlocked) {
-        gameMessage = "Goat's turn is skipped";
-        currentTurn = PieceType.tiger;
-        notifyListeners();
-        return;
-      }
-    } else {
-      currentTurn = PieceType.tiger;
-    }
+    currentTurn = currentTurn == PieceType.tiger ? PieceType.goat : PieceType.tiger;
     selectedPiece = null;
     validMoves = [];
     if (gameMessage == "Goat's turn is skipped") gameMessage = null;
@@ -1056,18 +1040,7 @@ class GameController extends ChangeNotifier {
     } else {
       if (validMoves.contains(point)) {
         _executeMove(selectedPiece!, point);
-        if (currentTurn == PieceType.tiger) {
-          currentTurn = PieceType.goat;
-          bool allBlocked = _areAllGoatsBlocked();
-          if (allBlocked) {
-            gameMessage = "Goat's turn is skipped";
-            currentTurn = PieceType.tiger;
-            notifyListeners();
-            return;
-          }
-        } else {
-          currentTurn = PieceType.tiger;
-        }
+        currentTurn = currentTurn == PieceType.tiger ? PieceType.goat : PieceType.tiger;
       }
       selectedPiece = null;
       validMoves = [];


### PR DESCRIPTION
Fixes AI and human tiger turns to allow only one move per turn, then switches to the opponent.

---
<a href="https://cursor.com/background-agent?bcId=bc-49c5c454-53d3-4f66-914e-cbcbc685e4d4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-49c5c454-53d3-4f66-914e-cbcbc685e4d4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

