### PR TITLE
Fix single tiger move in ai

### DIFF
--- a/lib/logic/game_controller.dart
+++ b/lib/logic/game_controller.dart
@@ -1217,15 +1217,21 @@ class GameController extends ChangeNotifier {
       PieceType currentTurnClone = currentTurn;
 
       if (boardType == BoardType.square) {
+        final fromClone = boardClone![move['from']!.x][move['from']!.y];
+        final toClone = boardClone[move['to']!.x][move['to']!.y];
         square.SquareBoardLogic.executeMove(
-          move['from']!,
-          move['to']!,
-          boardClone!,
+          fromClone,
+          toClone,
+          boardClone,
         );
       } else if (boardType == BoardType.aaduPuli && boardConfigClone != null) {
+        final fromClone = boardConfigClone.nodes
+            .firstWhere((n) => n.id == move['from']!.id);
+        final toClone = boardConfigClone.nodes
+            .firstWhere((n) => n.id == move['to']!.id);
         aadu.AaduPuliLogic.executeMove(
-          move['from']!,
-          move['to']!,
+          fromClone,
+          toClone,
           boardConfigClone,
         );
       }
@@ -1341,9 +1347,13 @@ class GameController extends ChangeNotifier {
       int cgClone = capturedGoatsClone;
       int pgClone = placedGoatsClone;
       if (boardType == BoardType.square && bClone != null) {
-        square.SquareBoardLogic.executeMove(move['from']!, move['to']!, bClone);
+        final fromClone = bClone[move['from']!.x][move['from']!.y];
+        final toClone = bClone[move['to']!.x][move['to']!.y];
+        square.SquareBoardLogic.executeMove(fromClone, toClone, bClone);
       } else if (boardType == BoardType.aaduPuli && bcClone != null) {
-        aadu.AaduPuliLogic.executeMove(move['from']!, move['to']!, bcClone);
+        final fromClone = bcClone.nodes.firstWhere((n) => n.id == move['from']!.id);
+        final toClone = bcClone.nodes.firstWhere((n) => n.id == move['to']!.id);
+        aadu.AaduPuliLogic.executeMove(fromClone, toClone, bcClone);
       }
       bool isCapture = !_areAdjacent(move['from']!, move['to']!);
       if (isCapture) cgClone++;


### PR DESCRIPTION
Fixes an issue where the AI's minimax search could mutate the live game board, causing multiple tiger moves in one turn.

The minimax algorithm was executing simulated moves using original `Point` or `Node` references while evaluating on cloned boards. This could inadvertently modify the actual game state, leading to the appearance of multiple tiger moves within a single AI turn. The fix ensures that all `from` and `to` points/nodes used in the simulation are explicitly resolved from the cloned board/config, preventing any unintended side effects on the real board.

---
<a href="https://cursor.com/background-agent?bcId=bc-c29ccb90-3241-4ea2-99c9-e047cbe18f97">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c29ccb90-3241-4ea2-99c9-e047cbe18f97">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

