### PR TITLE
Improve tiger ai goat capture logic

### DIFF
--- a/lib/logic/game_controller.dart
+++ b/lib/logic/game_controller.dart
@@ -1201,11 +1201,23 @@ class GameController extends ChangeNotifier {
     double alpha,
     double beta,
   ) {
+    // In hard mode, if it's the tiger's move and a capture is available,
+    // restrict consideration to capture moves so AI always captures when possible.
+    final List<Map<String, Point>> movesToConsider =
+        (difficulty == Difficulty.hard && currentTurn == PieceType.tiger)
+            ? (() {
+                final caps = moves
+                    .where((m) => _isJump(m['from']!, m['to']!))
+                    .toList();
+                return caps.isNotEmpty ? caps : moves;
+              })()
+            : moves;
+
     Map<String, Point>? bestMove;
     double bestValue =
         maximizingPlayer ? double.negativeInfinity : double.infinity;
 
-    for (final move in moves) {
+    for (final move in movesToConsider) {
       var boardClone =
           boardType == BoardType.square ? _cloneSquareBoard(board) : null;
       var boardConfigClone =
@@ -1318,7 +1330,7 @@ class GameController extends ChangeNotifier {
         if (beta <= alpha) break;
       }
     }
-    return bestMove ?? moves.first;
+    return bestMove ?? movesToConsider.first;
   }
 
   double _minimaxValue(


### PR DESCRIPTION
Prioritize capture moves for hard-mode Tiger AI to ensure goats are killed when possible.

The hard-mode AI for tigers previously did not explicitly prioritize capture moves, leading to tigers sometimes making non-capturing moves even when a goat could be captured. This change modifies the minimax algorithm to filter candidate moves to only include captures if any are available, ensuring the AI takes immediate killing opportunities.

---
<a href="https://cursor.com/background-agent?bcId=bc-f139bda6-f1b7-40d4-b558-41342108355e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f139bda6-f1b7-40d4-b558-41342108355e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

