### PR TITLE
Handle unbeatable difficulty in switch

### DIFF
--- a/lib/logic/game_controller.dart
+++ b/lib/logic/game_controller.dart
@@ -999,6 +999,14 @@ class GameController extends ChangeNotifier {
             double.negativeInfinity,
             double.infinity,
           );
+        case Difficulty.unbeatable:
+          return _minimaxMove(
+            moves,
+            3,
+            true,
+            double.negativeInfinity,
+            double.infinity,
+          );
       }
     }
     return moves[_randomInt(moves.length)];


### PR DESCRIPTION
Add `Difficulty.unbeatable` case to the tiger move selection switch to fix an exhaustive switch error and implement unbeatable AI logic.

---
<a href="https://cursor.com/background-agent?bcId=bc-19c66364-19d9-493d-8d05-6c968c128d24">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-19c66364-19d9-493d-8d05-6c968c128d24">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

